### PR TITLE
ci: bump FreeBSD VM to 14.4 to match the pkg repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build textedit inside FreeBSD VM
         uses: vmactions/freebsd-vm@v1
         with:
-          release: "14.3"
+          release: "14.4"
           usesh: true
           sync: rsync
           copyback: false


### PR DESCRIPTION
The `vmactions/freebsd-vm` image was pinned to **14.3** while FreeBSD's package repo advanced to **14.4**, so `pkg install` aborts with:

```
wrong version ... To ignore this error set IGNORE_OSVERSION=yes
```

before anything builds. Bumping the VM to **14.4** matches the repo and clears the FreeBSD job.

This is the same one-line fix already applied to the other Gershwin build targets (`gershwin-developer`, `gershwin-components`, `gershwin-workspace`, `gershwin-eau-theme`, `gershwin-terminal`, `gershwin-windowmanager`) — this finishes the two that were missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)